### PR TITLE
Sum rewards rather than count

### DIFF
--- a/RaidCrawler.Core/Structures/RaidFilter.cs
+++ b/RaidCrawler.Core/Structures/RaidFilter.cs
@@ -68,7 +68,7 @@ namespace RaidCrawler.Core.Structures
                 return true;
 
             var rewards = enc.GetRewards(container, raid, sandwichBoost);
-            var count = rewards.Where(z => RewardItems.Contains(z.Item1)).Count();
+            var count = rewards.Where(z => RewardItems.Contains(z.Item1)).Sum(o => o.Item2);
             return RewardsComp switch
             {
                 0 => count == RewardsCount,


### PR DESCRIPTION
This allows for proper counts of things like tera shards, that are given out in bulk.

With this change it may be useful to increase the limit for reward counting in the UI beyond 12, as tera shards can be rewarded in higher amounts